### PR TITLE
Fix hyperlink post summary issue

### DIFF
--- a/newsletter.html
+++ b/newsletter.html
@@ -23,7 +23,7 @@ scripts:
       <h2 class="post-title">{{ post.title }}</h2>
       <h3 class="post-date">{{ post.date | date: "%b %-d, %Y"}}</h3>
       <div class="post-excerpt">
-        {{ post.excerpt }}
+        <p>{{ post.excerpt | strip_html }}</p>
       </div>
     </div>
   </a>


### PR DESCRIPTION
According to the HTML spec, <a> tags cannot be nested. Therefore, when
the content of the post includes an <a> tag, it causes strange browser
interactions.

To fix this, we simply remove all html tags from the post excerpt before
displaying it, so that there will never be links inside the post.

This fixes #29.