### PR TITLE
Create old committee archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,15 @@ and dates given in the calendar event. The below table details the process:
 
 To update the committee:
 
-1. Remove the old committee's photos from `assets/committee/`
-2. Add the new committee's photos into `assets/committee/full`
+1. Add the new committee's photos into `assets/committee/full`
     - Each image should have a 1:1 ratio.
     - Add the highest quality images you can (they'll be scaled down later).
     - Most common image formats are supported.
-3. Create all the additional files by running `_scripts/committee.sh`
-2. Edit `_data/committee.yaml` with the correct academic year and the new
-   committee's details and pictures (make sure to use the `mini` images).
+2. Create all the additional files by running `_scripts/committee.sh` (it's a
+   bash shell script).
+3. Prepend a yaml object with the correct academic year and the new
+   committee's details and pictures (make sure to use the `mini` images
+   generated in the above step) to `data/committee.yaml`.
 
 [calendar]: https://calendar.google.com/calendar/embed?src=kg5v9k480jn2qahpmq33h8g7cs%40group.calendar.google.com&ctz=Europe%2FLondon
 [fullcalendar]: https://fullcalendar.io/

--- a/_data/committee.yaml
+++ b/_data/committee.yaml
@@ -1,6 +1,6 @@
-- academic_year: 2020/2021
-  people:
-    ...
+# - academic_year: 2020/2021
+#   people:
+#     ...
 - academic_year: 2019/2020
   people:
     - name: Cristian Calauz

--- a/_data/committee.yaml
+++ b/_data/committee.yaml
@@ -1,99 +1,102 @@
-academic_year: 2019/2020
-people:
-  - name: Cristian Calauz
-    role: President
-    bio: >
-      As the president of CSS, I oversee and manage the committee and the
-      society. I also engage in the recreational sport of watching paint dry,
-      play video games, hear grass grow, and laugh at the futility of time.
-    picture: /assets/committee/mini/cristian.jpg
-  - name: Tom Goodman
-    role: Secretary
-    bio: >
-      I'm Tom, a 2nd year PhD student here at the uni. I did my BSc here too,
-      and I've been involved with CSS since my first year, and was president
-      from 2016 to 2019 - I'm the secretary this year, and looking forward to
-      meeting y'all! 🎉
-    picture: /assets/committee/mini/tomg.jpg
-  - name: Stefan Nedelcu
-    role: Treasurer
-    bio: >
-      As Treasurer, I look after the finances of our society, ensuring every
-      transaction is made by the book. Some would say the computer science
-      building is my second home as people can often find me in the labs at
-      unusual hours.
-    picture: /assets/committee/mini/stefan.jpg
-  - name: Justin Chadwell
-    role: Vice-President
-    bio: >
-      My job within the committee is to help the society run smoothly, so I
-      do lots of odd jobs, like work on this website. When not on CSS
-      business, I'm taking part in hackathons across the UK, hacking with
-      AFNOM, or spending too much time on assorted projects.
-    picture: /assets/committee/mini/justin.jpg
-  - name: Jonathan Rudman
-    role: Socials Rep
-    bio: >
-      As CSS socials rep, I ensure that social events occur frequently and
-      that these events are designed around our members. When I’m not
-      organising events, I’m often found wasting my time on configs.
-    picture: /assets/committee/mini/jonty.jpg
-  - name: Selma Kander
-    role: International Rep
-    bio: >
-      Hi I’m selma, international rep for CSS. My goal is to make sure
-      international CS students feel at home here! Feel free to hit me up if
-      you need help settling in 🙂
-    picture: /assets/committee/mini/selma.jpg
-  - name: Lauren Alie
-    role: Special Events Rep
-    bio: >
-      As Special Events rep, I'm responsible for making sure that all big CSS
-      events during the year, such as the CSS ball, are the best they can be.
-      Outside CSS I enjoy dancing and playing in a steel drum orchestra.
-    picture: /assets/committee/mini/lauren.jpg
-  - name: Keerthi Rachmallu
-    role: Diversity and Inclusivity Rep
-    bio: >
-      I’m the Diversity, Inclusivity and Equality Representative, or as I
-      like to be called, the DIE rep for CSS. When I’m not doing nerdy comp
-      sci stuff, I’m usually binge watching shows or eating carrots from
-      Tesco.
-    picture: /assets/committee/mini/keerthi.jpg
-  - name: Laura Cope
-    role: Sports Rep
-    bio: >
-      Within the committee I organise any sporting events, not forgetting
-      e-sports. In my free time I play ice hockey, cycle and do and any other
-      sports I fit in. I also love a host of classic and recent video
-      games which I can't wait to bring to CSS.
-    picture: /assets/committee/mini/laura.jpg
-  - name: Lik Kan Chung
-    role: Publicity Rep
-    bio: >
-      Hi. I'm Likkan, I'm a third year undergrad. I'm the publicity rep so my
-      job is to make all the posters and post on social media. Other things I
-      do outside of CSS are help organise events like HackTheMidlands and I'm
-      also a student ambassador for the department
-    picture: /assets/committee/mini/likkan.jpg
-  - name: Tom Preece
-    role: Industrial Rep
-    bio: >
-      I'm the committee's link to the world of industry, ensuring that the
-      society is relevant and on top of changes. I also represents the
-      students away in industry. In my own time, I play guitar and enjoy
-      some casual game development.
-    picture: /assets/committee/mini/tomp.jpg
-  - name: Valeria Popescu
-    role: First Year Rep
-    bio: >
-      Hi! My name is Valeria and my goal is to make sure that first-year
-      students are well informed and involved in all the opportunities out
-      there in CS and having their best time at university. Outside CSS I
-      like participating in programming contests, hackathons and watching
-      bachata dancing.
-    picture: /assets/committee/mini/valeria.jpg
-  - name: Marco Canducci
-    role: Post-Graduate (Research) Rep
-    bio:
-    picture: /assets/committee/mini/marco.jpg
+- academic_year: 2020/2021
+  people:
+    ...
+- academic_year: 2019/2020
+  people:
+    - name: Cristian Calauz
+      role: President
+      bio: >
+        As the president of CSS, I oversee and manage the committee and the
+        society. I also engage in the recreational sport of watching paint dry,
+        play video games, hear grass grow, and laugh at the futility of time.
+      picture: /assets/committee/mini/cristian.jpg
+    - name: Tom Goodman
+      role: Secretary
+      bio: >
+        I'm Tom, a 2nd year PhD student here at the uni. I did my BSc here too,
+        and I've been involved with CSS since my first year, and was president
+        from 2016 to 2019 - I'm the secretary this year, and looking forward to
+        meeting y'all! 🎉
+      picture: /assets/committee/mini/tomg.jpg
+    - name: Stefan Nedelcu
+      role: Treasurer
+      bio: >
+        As Treasurer, I look after the finances of our society, ensuring every
+        transaction is made by the book. Some would say the computer science
+        building is my second home as people can often find me in the labs at
+        unusual hours.
+      picture: /assets/committee/mini/stefan.jpg
+    - name: Justin Chadwell
+      role: Vice-President
+      bio: >
+        My job within the committee is to help the society run smoothly, so I
+        do lots of odd jobs, like work on this website. When not on CSS
+        business, I'm taking part in hackathons across the UK, hacking with
+        AFNOM, or spending too much time on assorted projects.
+      picture: /assets/committee/mini/justin.jpg
+    - name: Jonathan Rudman
+      role: Socials Rep
+      bio: >
+        As CSS socials rep, I ensure that social events occur frequently and
+        that these events are designed around our members. When I’m not
+        organising events, I’m often found wasting my time on configs.
+      picture: /assets/committee/mini/jonty.jpg
+    - name: Selma Kander
+      role: International Rep
+      bio: >
+        Hi I’m selma, international rep for CSS. My goal is to make sure
+        international CS students feel at home here! Feel free to hit me up if
+        you need help settling in 🙂
+      picture: /assets/committee/mini/selma.jpg
+    - name: Lauren Alie
+      role: Special Events Rep
+      bio: >
+        As Special Events rep, I'm responsible for making sure that all big CSS
+        events during the year, such as the CSS ball, are the best they can be.
+        Outside CSS I enjoy dancing and playing in a steel drum orchestra.
+      picture: /assets/committee/mini/lauren.jpg
+    - name: Keerthi Rachmallu
+      role: Diversity and Inclusivity Rep
+      bio: >
+        I’m the Diversity, Inclusivity and Equality Representative, or as I
+        like to be called, the DIE rep for CSS. When I’m not doing nerdy comp
+        sci stuff, I’m usually binge watching shows or eating carrots from
+        Tesco.
+      picture: /assets/committee/mini/keerthi.jpg
+    - name: Laura Cope
+      role: Sports Rep
+      bio: >
+        Within the committee I organise any sporting events, not forgetting
+        e-sports. In my free time I play ice hockey, cycle and do and any other
+        sports I fit in. I also love a host of classic and recent video
+        games which I can't wait to bring to CSS.
+      picture: /assets/committee/mini/laura.jpg
+    - name: Lik Kan Chung
+      role: Publicity Rep
+      bio: >
+        Hi. I'm Likkan, I'm a third year undergrad. I'm the publicity rep so my
+        job is to make all the posters and post on social media. Other things I
+        do outside of CSS are help organise events like HackTheMidlands and I'm
+        also a student ambassador for the department
+      picture: /assets/committee/mini/likkan.jpg
+    - name: Tom Preece
+      role: Industrial Rep
+      bio: >
+        I'm the committee's link to the world of industry, ensuring that the
+        society is relevant and on top of changes. I also represents the
+        students away in industry. In my own time, I play guitar and enjoy
+        some casual game development.
+      picture: /assets/committee/mini/tomp.jpg
+    - name: Valeria Popescu
+      role: First Year Rep
+      bio: >
+        Hi! My name is Valeria and my goal is to make sure that first-year
+        students are well informed and involved in all the opportunities out
+        there in CS and having their best time at university. Outside CSS I
+        like participating in programming contests, hackathons and watching
+        bachata dancing.
+      picture: /assets/committee/mini/valeria.jpg
+    - name: Marco Canducci
+      role: Post-Graduate (Research) Rep
+      bio:
+      picture: /assets/committee/mini/marco.jpg

--- a/committee-archive.html
+++ b/committee-archive.html
@@ -1,0 +1,26 @@
+---
+layout: page
+title: Committee Archive
+styles:
+  - /css/committee.css
+scripts:
+  - /js/fadein.js
+---
+
+{% for committee in site.data.committee offset:1 %}
+<h2>{{ committee.academic_year }}</h2>
+<div class="person-container fadein-container">
+  {% for person in committee.people %}
+  <div class="person fadein hidden">
+    <img class="picture" src="{{ person.picture | relative_url }}" alt="picture of {{ person.name }}">
+    <div class="details">
+      <span class="name">{{ person.name }}</span>
+      <span class="role">{{ person.role }}</span>
+      <p class="bio">
+        {{ person.bio }}
+      </p>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endfor %}

--- a/committee.html
+++ b/committee.html
@@ -15,12 +15,15 @@ scripts:
   running events throughout the year.
 </p>
 <p>
-  Currently, for the academic year {{ site.data.committee.academic_year }}
-  we have {{ site.data.committee.people.size }} committee members:
+  For previous years see <a href="/committee-archive.html">here</a>.
+</p>
+<p>
+  Currently, for the academic year {{ site.data.committee[0].academic_year }}
+  we have {{ site.data.committee[0].people.size }} committee members:
 </p>
 
 <div class="person-container fadein-container">
-  {% for person in site.data.committee.people %}
+  {% for person in site.data.committee[0].people %}
   <div class="person fadein hidden">
     <img class="picture" src="{{ person.picture | relative_url }}" alt="picture of {{ person.name }}">
     <div class="details">


### PR DESCRIPTION
This allows us to keep track of old committees, by keeping them around in the yaml file. When we have a new committee, we should **prepend** the new details at the start of the yaml file, as indicated by the comment.

I've also updated the README to reflect these new instructions.