### PR TITLE
Fix CSS property causing header buttons to be partially obstructed

### DIFF
--- a/css/type.scss
+++ b/css/type.scss
@@ -8,10 +8,9 @@ body {
 
 .lead {
   position: absolute;
-  top: 5vh;
   left: 0;
   width: 100vw;
-  height: 95vh;
+  height: 78vh;
 }
 
 .ascii-container {


### PR DESCRIPTION
Description
---

The `top` property used in the `lead` class "invisibly" obstructs the navigation buttons in the header. The
buttons are visible but not clickable wherever the lead frame overlaps.

Fix
---

- Remove `top` property inside `lead` class.
- Compensate removal by changing `height` to `78vh`.