### PR TITLE
Fixed guild logo taking up 100% width within Get Membership button

### DIFF
--- a/css/about.scss
+++ b/css/about.scss
@@ -29,6 +29,8 @@ h1, h2, h3, h4 {
 
 .text-img {
   height: 1em;
+  width: 1em;
+  display: inline;
 }
 
 #about-profile {


### PR DESCRIPTION
fixes #126

# Screenshots

## Before
<img width="1436" alt="Screenshot 2021-07-20 at 23 30 03" src="https://user-images.githubusercontent.com/36203880/126403985-8d96fe1f-15c5-47cb-9f87-e814906b818e.png">

## After
<img width="1392" alt="Screenshot 2021-07-20 at 23 29 44" src="https://user-images.githubusercontent.com/36203880/126403963-5f128481-972b-49f9-97f8-28f7af9e7d8b.png">
