### PR TITLE
Add redirect for Guild admin page

### DIFF
--- a/_data/redirects.yaml
+++ b/_data/redirects.yaml
@@ -45,6 +45,8 @@
 # uni
 - source: /guild
   destination: https://www.guildofstudents.com/studentgroups/societies/css/
+- source: /guild/admin
+  destination: https://www.guildofstudents.com/organisation/admin/6531/
 - source: /eps
   destination: https://www.birmingham.ac.uk/university/colleges/eps/eps-community/students/societies/css.aspx
 


### PR DESCRIPTION
Add redirect for committee admin page on Guild website. Makes it easier to navigate to if loggin in using mobile