### PR TITLE
increase soon.html target time

### DIFF
--- a/soon.html
+++ b/soon.html
@@ -13,7 +13,7 @@ styles:
 
 
 <script>
-    var countDownDate = new Date("Apr 28, 2022 00:00:00").getTime();
+    var countDownDate = new Date("Apr 28, 2022 18:00:00").getTime();
 
     var x = setInterval(function() {
         var now = new Date().getTime();


### PR DESCRIPTION
Some viewers have incorrectly looked at just the day countdown and assumed the date of the event is 27th, not 28th. Increasing target timer to approx 6pm will offset this.