### PR TITLE
Remove old members from committee

### DIFF
--- a/_data/committee/2021-22.yaml
+++ b/_data/committee/2021-22.yaml
@@ -7,6 +7,7 @@ people:
     discordtag: LikkanChung#6938
     role: President
     picture: /assets/committee/2021-22/mini/likkan.jpg
+    start-date: 1/7/2021
     bio: >
       I'm a final year on the MSci course, just coming back from my placement at Kainos. 
       You may also know me from organising HackTheMidlands, or as a Student Ambassador. 
@@ -17,6 +18,7 @@ people:
     discordtag: raenlok#9165
     role: Treasurer
     picture: /assets/committee/2021-22/mini/jacqui.jpg
+    start-date: 1/7/2021
     bio: >
       I'm Jacqui, the treasurer of CSS! My role is to manage the funds for CSS, making sure we have the ability to put on great events. 
       When I'm not stressing out over responsibilities and deadlines, I spend a lot of my time playing RPGs and drinking iced lemon tea.
@@ -26,6 +28,8 @@ people:
     discordtag: Rhysimus#9263
     role: Secretary
     picture: /assets/committee/2021-22/mini/rhys.jpg
+    start-date: 1/7/2021
+    end-date: 1/1/2022
     bio: >
       Hiya! I'm Rhys, a second year degree apprentice and your Secretary this year. 
       It's my job to organise and minute the meetings, as well as ensuring everyone's doing awesome. 
@@ -36,6 +40,7 @@ people:
     discordtag: BladorthinGrey#8528
     role: Vice-President
     picture: /assets/committee/2021-22/mini/jacob.jpg
+    start-date: 1/7/2021
     bio: >
       My role is keeping everything in the society ticking along and to help out where I can in all aspects of the committee. 
       If the President, Secretary or Treasurer can't make it, then I fill in for them in meetings. 
@@ -47,6 +52,8 @@ people:
     discordtag: Fatima#2285
     role: Interim First Year Rep
     picture: /assets/committee/2021-22/mini/fatima.jpg
+    start-date: 1/7/2021
+    end-date: 20/10/2021
     bio: >
       Hello everyone. My name is Fatima Zahra Al Hajji and I’m a first year student on the course ‘Artificial Intelligence and Computer Science with a year in industry’. 
       I enjoy cycling, reading and drawing as well as programming, of course. 
@@ -58,6 +65,7 @@ people:
     discordtag: aamnaam#7088
     role: International Student Rep
     picture: /assets/committee/2021-22/mini/aamaan.jpg
+    start-date: 1/7/2021
     bio: >
       Hey! I'm Aamaan. My job is to ensure all International Students enjoy their time at the university and receive support to ease the challenges that accompany a move to the new country. 
       In my free time (sometimes not so free), I like playing Rocket League and watching random YouTube videos!
@@ -67,6 +75,7 @@ people:
     discordtag: TheAxelr8r#7476
     role: Publicity Officer
     picture: /assets/committee/2021-22/mini/alex.jpg
+    start-date: 1/7/2021
     bio: >
       My job is to make sure all our members know all about the amazing events we do throughout the year, 
       and help the society reach even more people by encouraging people to sign up, especially throughout freshers. 
@@ -78,6 +87,7 @@ people:
     discordtag: ジャック#0394
     role: Special Events Officer
     picture: /assets/committee/2021-22/mini/jack.png
+    start-date: 1/7/2021
     bio: >
       Hey everyone! I’m Jack, a 1st year CS student on the Year Abroad course! 
       I will be responsible for handling all the larger events we run this year, including the CSS Ball, Christmas meal, Board Game Nights, 
@@ -88,6 +98,7 @@ people:
     discordtag: Leaf#0077
     role: Socials Secretary
     picture: /assets/committee/2021-22/mini/leaf.jpg
+    start-date: 1/7/2021
     bio: >
       My role on committee is organizing fun socials, workshops, & meetups for members. Outside of enjoying programming, 
       I love cosplaying, playing games, art, photography, baking, collecting sanrio merch, & puzzle solving. 
@@ -98,6 +109,8 @@ people:
     discordtag: Raine#8544
     role: Sports Secretary
     picture: /assets/committee/2021-22/mini/ryan.png
+    start-date: 1/7/2021
+    end-date: 15/1/2022
     bio: >
       Hello, I'm Ryan and I'm going into my 2nd year studying Computer Science. I will be responsible for all of your sports and e-Sports events this year -- 
       please let me know what you want to see! When I'm not sleeping I'm either speedrunning, participating in hackathons or working on programming projects.
@@ -107,6 +120,18 @@ people:
     discordtag: Sapphyre#5656
     role: Equality, Diversity, and Inclusivity Officer
     picture: /assets/committee/2021-22/mini/victoria.jpg
+    start-date: 1/7/2021
+    end-date: 28/1/2022
+    bio: >
+      Heya! I'm Victoria and this year I'll be making sure that everyone feels included and represented at all of our events and in our School. 
+      Outside of this, I enjoy game development, airsoft, snowboarding and playing guitar. Come to me if you need anything!
+  
+  - name: Victoria Tilley
+    pronouns: She/Her, They/Them
+    discordtag: Sapphyre#5656
+    role: Secretary
+    picture: /assets/committee/2021-22/mini/victoria.jpg
+    start-date: 29/1/2022
     bio: >
       Heya! I'm Victoria and this year I'll be making sure that everyone feels included and represented at all of our events and in our School. 
       Outside of this, I enjoy game development, airsoft, snowboarding and playing guitar. Come to me if you need anything!
@@ -116,6 +141,8 @@ people:
     discordtag: LyndonChan#5225
     role: Industrial Liaison
     picture: /assets/committee/2021-22/mini/lyndon.jpg
+    start-date: 1/7/2021
+    end-date: 15/2/2021
     bio: >
       Hi everyone. I am Lyndon, the Industrial Liaison of CSS this year. 
       My role is to build connection between the industry and the society by organizing different careers events. 
@@ -126,6 +153,8 @@ people:
     discordtag: jamesdickinson#3403
     role: Interim Post-Graduate Taught Rep
     picture: /assets/committee/2021-22/mini/james.jpg
+    start-date: 1/7/2021
+    end-date: 20/10/2021
     bio: >
       I’m James, an MSc Computer Science student. My role its help represent current and incoming masters students.
       In my free time, I love cycling, swimming, and reading. Feel free to contact me!
@@ -135,6 +164,7 @@ people:
     discordtag: danyc0#7106
     role: Post-Graduate (Research) Rep
     picture: /assets/committee/2021-22/mini/dan.png
+    start-date: 1/7/2021
     bio: >
       My job this year is to get more PhD and MRes students involved in CSS events.
       My research is in Cyber Security, focusing on the (in)security of

--- a/committee-archive.html
+++ b/committee-archive.html
@@ -9,9 +9,39 @@ scripts:
 
 <h1>Committee Archive</h1>
 
-{% for committees in site.data.committee %}
+{% assign committees = site.data.committee %}
+{% for committees in committees reversed %}
   {% assign committee = committees[1] %}
-  {% unless committee.current == true %}
+  {% if committee.current == true %}
+    <h2>{{ committee.academic_year}}</h2>
+    <div class="person-container fadein-container">
+      {% for person in committee.people %}
+        {% if person.end-date %}
+          <div class="person fadein hidden">
+            <img class="picture" src="{{ person.picture | relative_url }}" alt="picture of {{ person.name }}">
+            <div class="details">
+              <span class="name">{{ person.name }}</span>
+              {% if person.pronouns %}
+                <span class="pronouns">
+                  {{person.pronouns}}
+                </span>
+              {% endif %}
+              <p class="role">
+                {{ person.role }}
+                |
+                {% if person.start-date and person.end-date %}
+                  {{ person.start-date | date: "%b %Y" }} -
+                  {{ person.end-date | date: "%b %Y" | default: "Present" }}
+                {% endif %}
+              </p>
+              <p class="bio">
+                {{ person.bio }}
+              </p>
+            </div>
+          </div>
+        {% endif %}
+      {% endfor %}
+  {% else %}
     <h2>{{ committee.academic_year}}</h2>
     <div class="person-container fadein-container">
       {% for person in committee.people %}
@@ -33,6 +63,6 @@ scripts:
           </div>
         </div>
       {% endfor %}
-    {% endunless %}
+  {% endif %}
   </div>
 {% endfor %}

--- a/committee.html
+++ b/committee.html
@@ -30,6 +30,7 @@ scripts:
     {% assign committee = committees[1] %}
     {% if committee.current %}
       {% for person in committee.people %}
+        {% unless person.end-date %}
         <div class="person fadein hidden">
             <img class="picture" src="{{ person.picture | relative_url }}" alt="picture of {{ person.name }}">
           <div class="details">
@@ -44,12 +45,16 @@ scripts:
               {% if committee.prefix %}{{committee.prefix}}{% endif %}
               {{ person.role }}
               {% if committee.postfix %}{{committee.postfix}}{% endif %}
+              |
+              {{ person.start-date | date: "%b %Y" }} -
+              {{ person.end-date | date: "%b %Y" | default: "Present" }}
             </p>
             <p class="bio">
               {{ person.bio }}
             </p>
           </div>
         </div>
+        {% endunless %}
       {% endfor %}
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
ASAP fix to remove old committee members from current committee page.
Instead show them on the archive page
Not adding new members in this page, except for the one who has changed role