### PR TITLE
Add helper tools in Makefile

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+*
+!**/
+!*.scss
+!*.js
+
+_site
+/js/redirect.js

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,11 @@ If you have never used git before, we would recommend that you read the [GitHub'
 If you are new to contributing to open-source projects on GitHub, the general workflow is as follows:
 1. Fork this repository and clone it
 2. Create a branch off master
-3. Make your changes and commit them
-4. Push your local branch to your remote fork
-5. Open a new pull request on GitHub
+3. Make your changes
+    - Make sure to run `make fmt` to autoformat your code
+    - Make a commit with an explanatory commit message
+5. Push your local branch to your remote fork
+6. Open a new pull request on GitHub
 
 We recommend also reading the following if you're unsure or not confident:
 
@@ -47,7 +49,15 @@ If you happen to be doing a lot of technical work on the website, the [wiki](htt
 
 ### Code style
 
-In general, follow the formatting in the file you are editing. We also encourage you to limit the maximum length of individual lines to a reasonable limit, use double quotes instead of single, use spaces rather than tabs, and write hex in upper case.
+To enforce a consistent code style across files, we use [prettier](https://prettier.io/)
+to auto-format most of the code. This will automatically format your syntax to
+a specific style - if it doesn't generate pretty code, then the code probably
+needs a refactor and cleanup anyways. You can run prettier from within your IDE
+(which will have it's own way of running it), or by using the `make fmt` helper
+defined at the root of the repository.
+
+In addition to the automatic formatter, follow the formatting style in the file
+you are editing.
 
 ### Git commit messages
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2
+FROM ruby:2 as base
 
 RUN bundle config --global frozen 1 && \
     mkdir -p /vendor/bundle && \
@@ -10,6 +10,12 @@ RUN bundle install
 
 COPY . .
 
-EXPOSE 4000
-CMD bundle exec jekyll serve --host 0.0.0.0 --port 4000
+FROM base as build-step
+RUN bundle exec jekyll build
 
+FROM scratch as build
+COPY --from=build-step /usr/src/app/_site /
+
+FROM base as server
+EXPOSE 4000
+CMD bundle exec jekyll serve --host 0.0.0.0 --port 4000 --destination /tmp/_site

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: all build serve clean
+	
+all: build
+	
+build: clean
+	docker buildx build . --target build --output type=local,dest=./_site
+
+serve:
+	docker compose up --build
+
+clean:
+	rm -rf _site
+	
+fmt:
+	prettier . --write

--- a/README.md
+++ b/README.md
@@ -11,15 +11,28 @@ See in-depth documentation and maintainance guides at the
 
 ### Docker setup
 
-Ensure that you have docker and docker-compose installed.
+Ensure that you have docker and docker-compose installed, along with GNU Make:
 
 Then:
 
 ```bash
-docker compose up --build
+make serve
 ```
 
 The website should now be available at <http://127.0.0.1:4000>.
+
+You can also build the site into `_site`:
+
+```bash
+make build
+```
+
+To automatically run the code formatter, ensure that
+[prettier](https://prettier.io/) is installed, then:
+
+```bash
+make fmt
+```
 
 ### Manual setup (not recommended)
 

--- a/css/about.scss
+++ b/css/about.scss
@@ -1,11 +1,13 @@
 ---
 ---
 
-h1, h2, h3, h4 {
+h1,
+h2,
+h3,
+h4 {
   padding: 0;
   margin: 0;
 }
-
 
 #about {
   font-size: 18px;
@@ -59,7 +61,7 @@ h1, h2, h3, h4 {
 }
 
 #discord-button {
-  background-color: #738ADB;
+  background-color: #738adb;
   color: white;
   i {
     color: white;
@@ -75,7 +77,7 @@ h1, h2, h3, h4 {
 }
 
 #about-us {
-  background-color: #F1F3F8;
+  background-color: #f1f3f8;
   border-radius: 10px;
   padding: 20px;
   font-size: 18px;
@@ -92,7 +94,7 @@ h1, h2, h3, h4 {
     grid-template-columns: repeat(3, 230px);
   }
 
-  @media (max-width: 1000px){
+  @media (max-width: 1000px) {
     #guild-and-uob-images {
       justify-content: center;
       align-items: center;
@@ -107,7 +109,7 @@ h1, h2, h3, h4 {
 }
 
 #social {
-  #social-buttons{
+  #social-buttons {
     justify-content: center;
     display: grid;
     grid-template-columns: repeat(3, 185px);
@@ -120,7 +122,7 @@ h1, h2, h3, h4 {
     text-decoration: none;
     text-align: center;
     font-size: 20px;
-    background-color: #F1F3F8;
+    background-color: #f1f3f8;
     border-radius: 20px;
     padding: 15px;
     margin-right: 10px;
@@ -129,21 +131,22 @@ h1, h2, h3, h4 {
       font-family: "Helvetica Neue", sans-serif;
       margin: 0;
     }
-    h4, i {
+    h4,
+    i {
       color: white;
     }
   }
 
-  @media (max-width: 600px){
-    #social-buttons{
+  @media (max-width: 600px) {
+    #social-buttons {
       justify-content: center;
       display: grid;
       grid-template-columns: repeat(2, 185px);
     }
   }
 
-  @media (max-width: 400px){
-    #social-buttons{
+  @media (max-width: 400px) {
+    #social-buttons {
       justify-content: center;
       display: grid;
       grid-template-columns: 185px;
@@ -151,7 +154,7 @@ h1, h2, h3, h4 {
   }
 
   .facebook {
-    background-color: #1877F2;
+    background-color: #1877f2;
   }
 
   .insta {
@@ -159,20 +162,20 @@ h1, h2, h3, h4 {
   }
 
   .twitter {
-    background-color: #00A1F3;
+    background-color: #00a1f3;
   }
 
   .linkedin {
-    background-color: #0077B5;
+    background-color: #0077b5;
   }
 
   .youtube {
-    background-color: #EA3223;
-  }      
-  
+    background-color: #ea3223;
+  }
+
   .github {
-    background-color: #161B22;
-  }      
+    background-color: #161b22;
+  }
 }
 
 #sponsors {
@@ -187,7 +190,7 @@ h1, h2, h3, h4 {
     justify-content: center;
     display: grid;
   }
- 
+
   .sponsors-link {
     display: inline-block;
     width: 280px;
@@ -203,13 +206,14 @@ h1, h2, h3, h4 {
       font-family: "Helvetica Neue", sans-serif;
       margin: 0;
     }
-    h4, i {
+    h4,
+    i {
       color: white;
     }
   }
 
-  @media (max-width: 400px){
-    #sponsors-images{
+  @media (max-width: 400px) {
+    #sponsors-images {
       justify-content: center;
       align-items: center;
       display: grid;
@@ -250,13 +254,14 @@ h1, h2, h3, h4 {
       font-family: "Helvetica Neue", sans-serif;
       margin: 0;
     }
-    h4, i {
+    h4,
+    i {
       color: white;
     }
   }
 
-  @media (max-width: 400px){
-    #constitution-buttons{
+  @media (max-width: 400px) {
+    #constitution-buttons {
       justify-content: center;
       display: grid;
       grid-template-columns: 185px;

--- a/css/ball/main.scss
+++ b/css/ball/main.scss
@@ -1,8 +1,8 @@
 ---
 ---
 
-@import url('https://fontlibrary.org//face/cmu-serif');
-@import url('https://fonts.googleapis.com/css2?family=Gentium+Book+Basic:wght@700&family=Ovo&display=swap');
+@import url("https://fontlibrary.org//face/cmu-serif");
+@import url("https://fonts.googleapis.com/css2?family=Gentium+Book+Basic:wght@700&family=Ovo&display=swap");
 
 $primary-background: #241040;
 $primary-lowlight: #0c0515;
@@ -17,311 +17,308 @@ $text: #fff;
 $font-primary: "Gentium Book Basic", "CMUSerifRoman", serif;
 $font-secondary: "Ovo", serif;
 
-
 html {
-    a { 
-        color: $secondary-highlight;
-        font-family: $font-secondary;
-        text-decoration: none;
-    }
+  a {
+    color: $secondary-highlight;
+    font-family: $font-secondary;
+    text-decoration: none;
+  }
 }
 
 header {
-    background-color: $secondary-lowlight;
-
+  background-color: $secondary-lowlight;
 }
 
 body {
-    width: 100%;
-    min-height: 100vh;
-    margin: 0;
+  width: 100%;
+  min-height: 100vh;
+  margin: 0;
 
-    background-image: url("/assets/events/ball/2022-background.png");
-    background-size: cover;
-    background-attachment: fixed;
-    background-color: $primary-background;
+  background-image: url("/assets/events/ball/2022-background.png");
+  background-size: cover;
+  background-attachment: fixed;
+  background-color: $primary-background;
 
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 
-    .text-center-div {
-        text-align: center;
-        margin-top: 2.5vh;
-        margin-bottom: 2.5vh;
+  .text-center-div {
+    text-align: center;
+    margin-top: 2.5vh;
+    margin-bottom: 2.5vh;
+  }
+
+  .avoidwrap {
+    display: inline-block;
+  }
+
+  .margin-top {
+    border-top: 3px solid $secondary-background;
+    margin-top: 10px;
+    padding-top: 10px;
+  }
+
+  .margin-bottom {
+    border-bottom: 3px solid $secondary-background;
+    margin-bottom: 10px;
+    padding-bottom: 10px;
+  }
+
+  .title {
+    font-size: 12vw;
+    margin-top: 2.5vh;
+    font-family: $font-primary;
+    color: $secondary-background;
+    text-shadow: 0.5vw 0.5vw 0.6vw $primary-lowlight;
+  }
+
+  .subtitle {
+    font-size: 60px;
+    margin-top: 2.5vh;
+    margin-bottom: 2.5vh;
+    font-family: $font-primary;
+    color: $secondary-background;
+    text-shadow: 2px 2px 3px $primary-lowlight;
+  }
+
+  .subsubtitle {
+    font-size: xx-large;
+    font-family: $font-secondary;
+    text-shadow: 1px 1px 2px $primary-lowlight;
+  }
+
+  .text-block {
+    margin-top: 1.25vh;
+    margin-bottom: 1.25vh;
+    font-family: $font-secondary;
+    font-size: x-large;
+  }
+
+  .button {
+    display: inline-block;
+    padding: 15px;
+    font-size: 20px;
+    font-weight: bold;
+    border-radius: 10px;
+    text-decoration: none;
+    font-family: $font-secondary;
+    width: 220px;
+    height: 25px;
+    margin: 5px 5px;
+    background-color: $secondary-lowlight;
+    color: $text;
+    &.empty {
+      filter: brightness(60%);
     }
-
-    .avoidwrap {
-        display: inline-block;
-    }
-
-    .margin-top {
-        border-top: 3px solid $secondary-background;
-        margin-top: 10px;
-        padding-top: 10px;
-    }
-    
-    .margin-bottom {
-        border-bottom: 3px solid $secondary-background;
-        margin-bottom: 10px;
-        padding-bottom: 10px;
-    }
-
-    .title {
-        font-size: 12vw;
-        margin-top: 2.5vh;
-        font-family: $font-primary;
-        color: $secondary-background;
-        text-shadow: 0.5vw 0.5vw 0.6vw $primary-lowlight;
-    }
-
-    .subtitle {
-        font-size: 60px;
-        margin-top: 2.5vh;
-        margin-bottom: 2.5vh;
-        font-family: $font-primary;
-        color: $secondary-background;
-        text-shadow: 2px 2px 3px $primary-lowlight;
-    }
-
-    .subsubtitle {
-        font-size: xx-large;
-        font-family: $font-secondary;
-        text-shadow: 1px 1px 2px $primary-lowlight;
-    }
-    
-    .text-block {
-        margin-top: 1.25vh;
-        margin-bottom: 1.25vh;
-        font-family: $font-secondary;
-        font-size: x-large;
-    }
-
-    .button {
-        display: inline-block;
-        padding: 15px;
-        font-size: 20px;
-        font-weight: bold;
-        border-radius: 10px;
-        text-decoration: none;
-        font-family: $font-secondary;
-        width: 220px;
-        height: 25px;
-        margin: 5px 5px;
-        background-color: $secondary-lowlight;
-        color: $text;
-        &.empty {
-            filter: brightness(60%);
-        }
-        &:not(.empty) {
-            box-shadow: 2px 2px 3px $primary-lowlight;
-            &:hover {
-                filter: brightness(110%);
-                box-shadow: 5px 5px 6px $primary-lowlight;
-            }
-        }
-    }
-
-    .dropdown {
-      font-family: $font-secondary;
-    }
-
-    .dropdown-content {
-      background-color: $secondary-lowlight;
-      
-      a {
-        font-family: $font-secondary;
-	font-size: 20px;
+    &:not(.empty) {
+      box-shadow: 2px 2px 3px $primary-lowlight;
+      &:hover {
+        filter: brightness(110%);
+        box-shadow: 5px 5px 6px $primary-lowlight;
       }
     }
+  }
 
-    .flex {
-         display: flex;
-         flex-direction: row;
+  .dropdown {
+    font-family: $font-secondary;
+  }
 
-         .flex-l {
-             flex: 0 1 auto;
-         }
-         .flex-r {
-             flex: 1 0 auto;
-         }
-     }
+  .dropdown-content {
+    background-color: $secondary-lowlight;
 
-    .section-details {
-        .venue-date{
-            font-size: 6vw;
-            font-weight: bold;
+    a {
+      font-family: $font-secondary;
+      font-size: 20px;
+    }
+  }
+
+  .flex {
+    display: flex;
+    flex-direction: row;
+
+    .flex-l {
+      flex: 0 1 auto;
+    }
+    .flex-r {
+      flex: 1 0 auto;
+    }
+  }
+
+  .section-details {
+    .venue-date {
+      font-size: 6vw;
+      font-weight: bold;
+    }
+    .countdown {
+      font-size: 4vw;
+    }
+    .subsubtitle {
+      margin: 5vh 1vw;
+    }
+    @media screen and (max-width: 800px) {
+      .title {
+        font-size: 20vw;
+      }
+      .venue-date {
+        font-size: 69px;
+      }
+      .countdown {
+        font-size: xx-large;
+      }
+    }
+  }
+
+  .section-venue {
+    margin-bottom: inherit;
+    position: relative;
+
+    .mobile-only {
+      display: none;
+    }
+    .description {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 400px;
+      height: 60vh;
+      background: linear-gradient(to left, #0000 0%, #0c0515d0 5%);
+      padding: 0 50px 0 20px;
+      margin: 10px 0;
+      max-height: 500px;
+      .subtitle {
+        margin: 10px 0;
+      }
+    }
+    .image {
+      object-fit: cover;
+      object-position: 50% 25%;
+      max-width: None;
+      height: 60vh;
+      max-height: 500px;
+    }
+    @media screen and (max-width: 800px) {
+      .mobile-only {
+        display: revert;
+      }
+      .description {
+        position: static;
+        width: revert;
+        height: revert;
+        background: revert;
+        padding: revert;
+        .subtitle {
+          display: none;
         }
-        .countdown{
-            font-size: 4vw;
-        }
-        .subsubtitle{
-            margin: 5vh 1vw;
-        }
-        @media screen and (max-width: 800px) {
-            .title {
-                font-size: 20vw;
-            }
-            .venue-date{
-                font-size: 69px;
-            }
-            .countdown{
-                font-size: xx-large;
-            }
-        }
+      }
+    }
+  }
+
+  .section-hashtag {
+    .hashtag {
+      font-size: 130px;
+      margin: auto;
+    }
+    .hashtag-buttons {
+      display: inline-grid;
+      margin: 0 auto;
+      flex: 0 0 auto;
     }
 
-    .section-venue {
-        margin-bottom: inherit;
-        position: relative;
+    @media screen and (max-width: 1114px) {
+      flex-direction: column;
 
-        .mobile-only {
-            display: none;
-        }
-        .description {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 400px;
-            height: 60vh;
-            background: linear-gradient(to left, #0000 0%, #0c0515d0 5%);
-            padding: 0 50px 0 20px;
-            margin: 10px 0;
-            max-height: 500px;
-            .subtitle {
-                margin: 10px 0;
-            }
-        }
-        .image {
-            object-fit: cover;
-            object-position: 50% 25%;
-            max-width: None;
-            height: 60vh;
-            max-height: 500px;
-        }
-        @media screen and (max-width: 800px){
-            .mobile-only {
-                display: revert;
-            }
-            .description {
-                position: static;
-                width: revert;
-                height: revert;
-                background: revert;
-                padding: revert;
-                .subtitle {
-                    display: none;
-                }
-            }
-        }
+      .hashtag {
+        font-size: 16vw;
+      }
+      .hashtag-buttons {
+        display: block;
+      }
     }
+  }
 
-    .section-hashtag {
-        .hashtag {
-            font-size: 130px;
-            margin: auto;
-        }
-        .hashtag-buttons {
-            display: inline-grid;
-            margin: 0 auto;
-            flex: 0 0 auto
-        }
+  .section-dj {
+    margin-bottom: inherit;
+    position: relative;
 
-
-        @media screen and (max-width: 1114px){
-            flex-direction: column;
-
-            .hashtag {
-                font-size: 16vw;
-            }
-            .hashtag-buttons {
-                display: block;
-            }
-        }
+    .mobile-only {
+      display: none;
     }
-
-    .section-dj {
-        margin-bottom: inherit;
-        position: relative;
-
-        .mobile-only {
-            display: none;
-        }
-        .description {
-            position: absolute;
-            top: 0;
-            right: 0;
-            width: 400px;
-            height: 60vh;
-            background: linear-gradient(to right, #0000 0%, #0c0515d0 5%);
-            padding: 0 20px 0 50px;
-            margin: 10px 0;
-            max-height: 500px;
-            .subtitle {
-                margin: 10px 0;
-            }
-        }
-        .image {
-            object-fit: cover;
-            object-position: 50% 30%;
-            max-width: None;
-            height: 60vh;
-            max-height: 500px;
-        }
-        @media screen and (max-width: 800px){
-            .mobile-only {
-                display: revert;
-            }
-            .description {
-                position: static;
-                width: revert;
-                height: revert;
-                background: revert;
-                padding: revert;
-                .subtitle {
-                    display: none;
-                }
-            }
-        }
+    .description {
+      position: absolute;
+      top: 0;
+      right: 0;
+      width: 400px;
+      height: 60vh;
+      background: linear-gradient(to right, #0000 0%, #0c0515d0 5%);
+      padding: 0 20px 0 50px;
+      margin: 10px 0;
+      max-height: 500px;
+      .subtitle {
+        margin: 10px 0;
+      }
     }
-
-    .section-faq {
-        .faq {
-            border-top: 2px solid rgba(255, 255, 255, 0.3);
-
-            padding-top: 5px;
-            margin: auto;
-            width: 70%;
-
-            .question {
-                font-weight: bold;
-            }
-        }
+    .image {
+      object-fit: cover;
+      object-position: 50% 30%;
+      max-width: None;
+      height: 60vh;
+      max-height: 500px;
     }
+    @media screen and (max-width: 800px) {
+      .mobile-only {
+        display: revert;
+      }
+      .description {
+        position: static;
+        width: revert;
+        height: revert;
+        background: revert;
+        padding: revert;
+        .subtitle {
+          display: none;
+        }
+      }
+    }
+  }
+
+  .section-faq {
+    .faq {
+      border-top: 2px solid rgba(255, 255, 255, 0.3);
+
+      padding-top: 5px;
+      margin: auto;
+      width: 70%;
+
+      .question {
+        font-weight: bold;
+      }
+    }
+  }
 }
 
 .menu {
-    .menu-section-title {
-        font-size: 60px;
-        margin-top: 5vh;
-        font-family: $font-primary;
-    }
+  .menu-section-title {
+    font-size: 60px;
+    margin-top: 5vh;
+    font-family: $font-primary;
+  }
 
-    .menu-item-container {
-        padding: 10pt;
-        border-top: 2px solid rgba(255, 255, 255, 0.3);
-        margin: auto;
-        width: 80%;
-    }
-    
-    .menu-item {
-        font-family: $font-secondary;
-        margin-bottom: 2.5vh;
-        display: inline;
-    }
+  .menu-item-container {
+    padding: 10pt;
+    border-top: 2px solid rgba(255, 255, 255, 0.3);
+    margin: auto;
+    width: 80%;
+  }
 
-    .menu-type {
-        font-family: $font-secondary;
-        color: $secondary-background;
-        display: inline;
-    }
+  .menu-item {
+    font-family: $font-secondary;
+    margin-bottom: 2.5vh;
+    display: inline;
+  }
+
+  .menu-type {
+    font-family: $font-secondary;
+    color: $secondary-background;
+    display: inline;
+  }
 }

--- a/css/calendar.scss
+++ b/css/calendar.scss
@@ -1,10 +1,10 @@
 ---
 ---
 
-$CSS-Blue:      #2f3c63;
-$CSS-Mid-Blue:  #101939;
+$CSS-Blue: #2f3c63;
+$CSS-Mid-Blue: #101939;
 $CSS-Deep-Blue: #0a0f1e;
-$TeX-Purple:    #9d68dc;
+$TeX-Purple: #9d68dc;
 
 .calendar-controls {
   margin-left: auto;
@@ -14,23 +14,23 @@ $TeX-Purple:    #9d68dc;
 }
 
 .calendar-button {
-    border: 1px solid white;
-    border-radius: .25em;
-    padding: .4em .65em;
-    background-color: $CSS-Mid-Blue;
-    color: white;
-    vertical-align: middle;
-    font-size: 1em;
-    line-height: 1.5em;
-    font-family: inherit;
-    display: inline-block;
-    font-weight: 400;
-    text-align: center;
-    text-decoration: none;
+  border: 1px solid white;
+  border-radius: 0.25em;
+  padding: 0.4em 0.65em;
+  background-color: $CSS-Mid-Blue;
+  color: white;
+  vertical-align: middle;
+  font-size: 1em;
+  line-height: 1.5em;
+  font-family: inherit;
+  display: inline-block;
+  font-weight: 400;
+  text-align: center;
+  text-decoration: none;
 
-    &:hover {
-      background-color:$CSS-Deep-Blue;
-    }
+  &:hover {
+    background-color: $CSS-Deep-Blue;
+  }
 }
 
 .calendar-container {
@@ -39,14 +39,15 @@ $TeX-Purple:    #9d68dc;
   margin-right: auto;
 }
 
-.calendar-event{
+.calendar-event {
   background-color: white;
   padding: 10px;
   border-radius: 10px;
   margin-bottom: 10px;
   display: none;
 
-  h2, p { 
+  h2,
+  p {
     color: black;
     text-align: left;
   }
@@ -63,9 +64,9 @@ $TeX-Purple:    #9d68dc;
 
   .event-pre {
     font-family: "JetBrains Mono", "Inconsolata", monospace;
-    white-space: pre-wrap; 
+    white-space: pre-wrap;
   }
-  
+
   .event-text {
     font-family: "Roboto", SansSerif;
     display: inline-block;
@@ -85,23 +86,28 @@ $TeX-Purple:    #9d68dc;
   padding: 20px;
   border-radius: 10px;
 
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     color: black;
   }
 
   .fc-button-primary {
     background-color: $CSS-Mid-Blue;
-    &:disabled{
+    &:disabled {
       opacity: 1;
       background-color: $CSS-Blue;
     }
     &:hover {
-      background-color:$CSS-Deep-Blue;
+      background-color: $CSS-Deep-Blue;
     }
   }
 
-  tbody tr td.fc-today  {
-    background: rgba($TeX-Purple,0.1);
+  tbody tr td.fc-today {
+    background: rgba($TeX-Purple, 0.1);
   }
 }
 
@@ -122,7 +128,6 @@ $TeX-Purple:    #9d68dc;
     width: 90%;
   }
 }
-
 
 @media only screen and (max-width: 900px) {
   .calendar-controls {

--- a/css/committee.scss
+++ b/css/committee.scss
@@ -28,7 +28,7 @@
     width: 150px;
     height: 100%;
     object-fit: cover;
-    flex: 0 0 auto;   
+    flex: 0 0 auto;
     border-right: 1px solid #222;
   }
 
@@ -74,7 +74,7 @@
   }
 }
 
-@media only screen and (max-width : 800px) {
+@media only screen and (max-width: 800px) {
   .person {
     flex-direction: column;
 
@@ -88,7 +88,7 @@
   }
 }
 
-@media only screen and (max-width : 1500px) {
+@media only screen and (max-width: 1500px) {
   .person-container {
     grid-template-columns: 1fr;
   }

--- a/css/hackathon-events.scss
+++ b/css/hackathon-events.scss
@@ -5,7 +5,9 @@ html {
   box-sizing: border-box;
 }
 
-*, *:before, *:after {
+*,
+*:before,
+*:after {
   box-sizing: inherit;
 }
 
@@ -33,21 +35,22 @@ html {
   background-color: white;
 }
 
-.container::after, .row::after {
+.container::after,
+.row::after {
   content: "";
   clear: both;
   display: table;
 }
 
-
 .name {
   font-size: large;
 }
 
-.date { 
+.date {
   font-size: small;
 }
-.name, .date {
+.name,
+.date {
   color: black;
   text-align: center;
 }
@@ -58,12 +61,12 @@ html {
   display: inline-block;
   padding: 8px;
   color: white;
-  background-color: #2E3C62;
+  background-color: #2e3c62;
   text-align: center;
   cursor: pointer;
   width: 100%;
 }
 
 .button:hover {
-  background-color: #25304F;
+  background-color: #25304f;
 }

--- a/css/main.scss
+++ b/css/main.scss
@@ -1,17 +1,17 @@
 ---
 ---
 
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,500;0,700;1,100&family=Roboto&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,500;0,700;1,100&family=Roboto&display=swap");
 
 @font-face {
   font-family: "Inconsolata";
   src: url(/fonts/Inconsolata-Regular.ttf) format("truetype");
 }
 
-$CSS-Blue:      #2f3c63;
-$CSS-Mid-Blue:  #101939;
+$CSS-Blue: #2f3c63;
+$CSS-Mid-Blue: #101939;
 $CSS-Deep-Blue: #0a0f1e;
-$TeX-Purple:    #9d68dc;
+$TeX-Purple: #9d68dc;
 
 body {
   width: 100%;
@@ -25,7 +25,7 @@ body {
 
 #freshers-banner {
   // display: none;
-  background-color: #9D68DC;
+  background-color: #9d68dc;
   border-radius: 10px;
   padding: 2px 20px;
   font-size: 18px;
@@ -48,7 +48,12 @@ main {
 
   flex: 1 1 auto;
 
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     color: white;
     font-family: "JetBrains Mono", "Inconsolata", monospace;
     font-weight: normal;
@@ -122,7 +127,7 @@ main {
     margin-left: auto;
     margin-right: auto;
   }
-  
+
   img {
     display: block;
     width: 100%;
@@ -164,7 +169,7 @@ header {
   .dropdown-content {
     display: none;
     position: absolute;
-    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
     margin-top: 1px;
     padding: 0;
     background-color: $CSS-Mid_Blue;
@@ -172,7 +177,7 @@ header {
     z-index: 10;
     left: 50%;
     transform: translateX(-50%);
-    
+
     a {
       display: block;
       color: black;
@@ -189,9 +194,10 @@ header {
     position: relative;
 
     // neat animations
-    &:before, &:after {
+    &:before,
+    &:after {
       position: absolute;
-      content: '';
+      content: "";
       width: 0;
       height: 1px;
       display: block;
@@ -206,7 +212,8 @@ header {
       right: 0;
     }
 
-    &:hover:before, &:hover:after {
+    &:hover:before,
+    &:hover:after {
       width: 100%;
       height: 1px;
     }
@@ -273,19 +280,21 @@ header {
       margin-right: 20px;
 
       a {
-        &:active, &:focus {
+        &:active,
+        &:focus {
           outline: none;
         }
       }
 
       button {
-	font-weight: 'normal';
+        font-weight: "normal";
       }
 
       &:before {
         display: none;
       }
-      &:first-child:before, &:after {
+      &:first-child:before,
+      &:after {
         position: relative;
         content: "";
         display: block;
@@ -343,7 +352,7 @@ header {
     .right {
       display: none;
     }
-    
+
     .hamburger {
       display: inline-block;
     }

--- a/css/posts.scss
+++ b/css/posts.scss
@@ -69,7 +69,8 @@ $preview-height: 150px;
     color: #9d68dc;
   }
 
-  .post-title, .post-date {
+  .post-title,
+  .post-date {
     margin: 0.1em 1ch 0.1em 0px;
     display: inline;
   }
@@ -86,7 +87,8 @@ $preview-height: 150px;
   table {
     border-collapse: collapse;
 
-    td, th {
+    td,
+    th {
       border: 1px solid black;
       padding: 0.4em;
     }
@@ -135,13 +137,10 @@ $preview-height: 150px;
     .post-quote-subtitle {
       margin-top: 0.5em;
       margin-bottom: 0.5em;
-
     }
     .post-quote-excerpt {
-
     }
   }
-
 }
 
 .post-header {
@@ -182,7 +181,6 @@ $preview-height: 150px;
       }
     }
   }
-
 }
 
 @media only screen and (max-width: 600px) {

--- a/css/tex.scss
+++ b/css/tex.scss
@@ -5,7 +5,9 @@ html {
   box-sizing: border-box;
 }
 
-*, *:before, *:after {
+*,
+*:before,
+*:after {
   box-sizing: inherit;
 }
 
@@ -13,12 +15,15 @@ table {
   width: 100%;
   border-collapse: collapse;
 
-  td, tr, th {
+  td,
+  tr,
+  th {
     padding: 10px;
     border: 1px solid #ccc;
   }
 
-  tr:nth-child(odd), th {
+  tr:nth-child(odd),
+  th {
     background-color: #f7f7f7;
   }
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,9 @@ version: '3.2'
 
 services:
   jekyll:
-    build: .
+    build:
+      context: .
+      target: server
     volumes:
       - "./:/usr/src/app"
     ports:

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1,254 +1,297 @@
 // API keys
 // these are generated using the google cloud platform api keys
-const CALENDAR_KEY = 'AIzaSyD-Dmwq4Nf0oSyaPdh_zM2NMqCgYnIRb14';
-const CALENDAR_ID = 'kg5v9k480jn2qahpmq33h8g7cs@group.calendar.google.com';
+const CALENDAR_KEY = "AIzaSyD-Dmwq4Nf0oSyaPdh_zM2NMqCgYnIRb14";
+const CALENDAR_ID = "kg5v9k480jn2qahpmq33h8g7cs@group.calendar.google.com";
 
 // constants for the look and feel of the calendar
-const STATE_LIST = 'listMonth';
-const STATE_GRID = 'dayGridMonth';
+const STATE_LIST = "listMonth";
+const STATE_GRID = "dayGridMonth";
 const TOGGLE_SIZE = 900;
 
 // used for clickable event information
-const MONTHS = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
 
 let state;
 let calendar;
 
-document.addEventListener('DOMContentLoaded', () => {
-	let calendarElement = document.getElementById('css-calendar');
-	let switchElement = document.getElementById('css-calendar-switch');
+document.addEventListener("DOMContentLoaded", () => {
+  let calendarElement = document.getElementById("css-calendar");
+  let switchElement = document.getElementById("css-calendar-switch");
 
-	state = window.innerWidth < TOGGLE_SIZE ? STATE_LIST : STATE_GRID;
-	let fixed = false;
+  state = window.innerWidth < TOGGLE_SIZE ? STATE_LIST : STATE_GRID;
+  let fixed = false;
 
-	calendar = new FullCalendar.Calendar(calendarElement, {
-		plugins: ['dayGrid', 'googleCalendar', 'list'],
-		height: 'auto',
-		header: {
-			left: 'title',
-			right: state == STATE_LIST ? 'prev next' : 'prev today next'
-		},
-		titleFormat: {
-			year: 'numeric',
-			month: 'long'
-		},
-		defaultView: state,
-		googleCalendarApiKey: CALENDAR_KEY,
-		events: {
-			googleCalendarId: CALENDAR_ID
-		},
-		eventColor: '#9d68dc',
-		eventClick: function(event) {
-			loadEvent(event);
-		}
-	});
-	calendar.render();
+  calendar = new FullCalendar.Calendar(calendarElement, {
+    plugins: ["dayGrid", "googleCalendar", "list"],
+    height: "auto",
+    header: {
+      left: "title",
+      right: state == STATE_LIST ? "prev next" : "prev today next",
+    },
+    titleFormat: {
+      year: "numeric",
+      month: "long",
+    },
+    defaultView: state,
+    googleCalendarApiKey: CALENDAR_KEY,
+    events: {
+      googleCalendarId: CALENDAR_ID,
+    },
+    eventColor: "#9d68dc",
+    eventClick: function (event) {
+      loadEvent(event);
+    },
+  });
+  calendar.render();
 
-	switchElement.addEventListener('click', () => {
-		fixed = true;
-		switch (state) {
-			case STATE_LIST:
-				refreshCalendar(STATE_GRID);
-				break;
-			case STATE_GRID:
-				refreshCalendar(STATE_LIST);
-				break;
-		}
-	})
+  switchElement.addEventListener("click", () => {
+    fixed = true;
+    switch (state) {
+      case STATE_LIST:
+        refreshCalendar(STATE_GRID);
+        break;
+      case STATE_GRID:
+        refreshCalendar(STATE_LIST);
+        break;
+    }
+  });
 
-	window.addEventListener('resize', () => {
-		if (!fixed) {
-			if (window.innerWidth < TOGGLE_SIZE) {
-				refreshCalendar(STATE_LIST);
-			} else {
-				refreshCalendar(STATE_GRID);
-			}
-		}
-	})
+  window.addEventListener("resize", () => {
+    if (!fixed) {
+      if (window.innerWidth < TOGGLE_SIZE) {
+        refreshCalendar(STATE_LIST);
+      } else {
+        refreshCalendar(STATE_GRID);
+      }
+    }
+  });
 
-	let eventCloseElement = document.getElementById('event-close');
-	eventCloseElement.addEventListener('click', () => {
-		hideEvent();
-	});
+  let eventCloseElement = document.getElementById("event-close");
+  eventCloseElement.addEventListener("click", () => {
+    hideEvent();
+  });
 });
 
 function refreshCalendar(nextState) {
-	if (nextState == state) {
-		return;
-	}
+  if (nextState == state) {
+    return;
+  }
 
-	state = nextState;
+  state = nextState;
 
-	calendar.changeView(state);
-	switch (state) {
-		case STATE_GRID:
-			calendar.setOption('header', {
-				left: 'title',
-				right: 'prev today next'
-			});
-			break;
-		case STATE_LIST:
-			calendar.setOption('header', {
-				left: 'title',
-				right: 'prev next'
-			});
-			break;
-	}
+  calendar.changeView(state);
+  switch (state) {
+    case STATE_GRID:
+      calendar.setOption("header", {
+        left: "title",
+        right: "prev today next",
+      });
+      break;
+    case STATE_LIST:
+      calendar.setOption("header", {
+        left: "title",
+        right: "prev next",
+      });
+      break;
+  }
 }
 
 function loadEvent(event) {
-	// fetch calendar data
-	if (event) {
-		event.jsEvent.preventDefault(); // don't let the browser navigate
+  // fetch calendar data
+  if (event) {
+    event.jsEvent.preventDefault(); // don't let the browser navigate
 
-		let title = "";
-		let date = "";
-		let location = "";
-		let description = "";
+    let title = "";
+    let date = "";
+    let location = "";
+    let description = "";
 
-		let eventData = event.event;
-		let eventDataExtended = eventData.extendedProps;
+    let eventData = event.event;
+    let eventDataExtended = eventData.extendedProps;
 
-		// title
-		title = eventData.title;
+    // title
+    title = eventData.title;
 
-		// date
-		let dash = " - ";
-		let colon = ":"
-		let space = " ";
-		let allDay = eventData.allDay;
-		let startMinute = ("0" + eventData.start.getMinutes()).slice(-2);
-		let endMinute = ("0" + eventData.end?.getMinutes()).slice(-2);
-		let startHour = ("0" + eventData.start.getHours()).slice(-2);
-		let endHour = ("0" + eventData.end?.getHours()).slice(-2);
-		let startDay = eventData.start.getDate();
-		let endDay = eventData.end?.getDate();
-		let startMonth = eventData.start.getMonth();
-		let endMonth = eventData.end?.getMonth();
-		let startYear = eventData.start.getFullYear()
-		let endYear = eventData.end?.getFullYear();
-		let startDate = "";
-		let endDate = "";
-		if (!eventData.end) {
-			// no end date
-			startDate = startDay + space + MONTHS[startMonth] + space + startYear + space + startHour + colon + startMinute;
-			dash = "";
-		} else if (startYear != endYear) {
-			// years differ - "dd MMM YYYY - dd MMM YYYY"
-			startDate = startDay + space + MONTHS[startMonth] + space + startYear;
-			endDate = endDay + space + MONTHS[endMonth] + space + endYear;
-			if (!allDay) {
-				// "dd MMM YYYY HH:MM - dd MMM YYYY HH:MM"
-				startDate += space + startHour + colon + startMinute;
-				endDate += space + startHour + colon + startMinute;
-			}
-		} else if (startMonth != endMonth) {
-			// same year, different month - "dd MMM - dd MMM"
-			startDate = startDay + space + MONTHS[startMonth];
-			endDate = endDay + space + MONTHS[endMonth];
-			if (!allDay) {
-				// "dd MMM HH:MM - dd MMM HH:MM"
-				startDate += space + startHour + colon + startMinute;
-				endDate += space + startHour + colon + startMinute;
-			}
-		} else if (startDay != endDay) {
-			// same year, same month, different day - "dd - dd MMM"
-			if (allDay) {
-				startDate = startDay;
-				endDate = endDay + space + MONTHS[endMonth];
-			} else {
-				// "dd MMMM HH:MM - dd MMM HH:MM"
-				startDate = startDay + space + MONTHS[startMonth] + space + startHour + colon + endMinute;
-				endDate = endDay + space + MONTHS[endMonth] + space + endHour + colon + endMinute;
-			}
-		} else {
-			// same day - "dd MMM HH:MM - HH:MM"
-			startDate = startDay + space + MONTHS[startMonth] + space + startHour + colon + startMinute;
-			endDate = endHour + colon + endMinute;
-		}
-		date = startDate + dash + endDate;
+    // date
+    let dash = " - ";
+    let colon = ":";
+    let space = " ";
+    let allDay = eventData.allDay;
+    let startMinute = ("0" + eventData.start.getMinutes()).slice(-2);
+    let endMinute = ("0" + eventData.end?.getMinutes()).slice(-2);
+    let startHour = ("0" + eventData.start.getHours()).slice(-2);
+    let endHour = ("0" + eventData.end?.getHours()).slice(-2);
+    let startDay = eventData.start.getDate();
+    let endDay = eventData.end?.getDate();
+    let startMonth = eventData.start.getMonth();
+    let endMonth = eventData.end?.getMonth();
+    let startYear = eventData.start.getFullYear();
+    let endYear = eventData.end?.getFullYear();
+    let startDate = "";
+    let endDate = "";
+    if (!eventData.end) {
+      // no end date
+      startDate =
+        startDay +
+        space +
+        MONTHS[startMonth] +
+        space +
+        startYear +
+        space +
+        startHour +
+        colon +
+        startMinute;
+      dash = "";
+    } else if (startYear != endYear) {
+      // years differ - "dd MMM YYYY - dd MMM YYYY"
+      startDate = startDay + space + MONTHS[startMonth] + space + startYear;
+      endDate = endDay + space + MONTHS[endMonth] + space + endYear;
+      if (!allDay) {
+        // "dd MMM YYYY HH:MM - dd MMM YYYY HH:MM"
+        startDate += space + startHour + colon + startMinute;
+        endDate += space + startHour + colon + startMinute;
+      }
+    } else if (startMonth != endMonth) {
+      // same year, different month - "dd MMM - dd MMM"
+      startDate = startDay + space + MONTHS[startMonth];
+      endDate = endDay + space + MONTHS[endMonth];
+      if (!allDay) {
+        // "dd MMM HH:MM - dd MMM HH:MM"
+        startDate += space + startHour + colon + startMinute;
+        endDate += space + startHour + colon + startMinute;
+      }
+    } else if (startDay != endDay) {
+      // same year, same month, different day - "dd - dd MMM"
+      if (allDay) {
+        startDate = startDay;
+        endDate = endDay + space + MONTHS[endMonth];
+      } else {
+        // "dd MMMM HH:MM - dd MMM HH:MM"
+        startDate =
+          startDay +
+          space +
+          MONTHS[startMonth] +
+          space +
+          startHour +
+          colon +
+          endMinute;
+        endDate =
+          endDay +
+          space +
+          MONTHS[endMonth] +
+          space +
+          endHour +
+          colon +
+          endMinute;
+      }
+    } else {
+      // same day - "dd MMM HH:MM - HH:MM"
+      startDate =
+        startDay +
+        space +
+        MONTHS[startMonth] +
+        space +
+        startHour +
+        colon +
+        startMinute;
+      endDate = endHour + colon + endMinute;
+    }
+    date = startDate + dash + endDate;
 
-		// location
-		location = eventDataExtended.location;
+    // location
+    location = eventDataExtended.location;
 
-		// description 
-		description = parseDescription(eventDataExtended.description);
+    // description
+    description = parseDescription(eventDataExtended.description);
 
-		// Facebook event button
-		let eventFacebookLinkElement = document.getElementById("facebook-link");
-		let link = parseFacebookLink(eventDataExtended.description);
-		if (link) {
-			eventFacebookLinkElement.onclick = () => {window.open(link)};
-			eventFacebookLinkElement.style.display = "inline";
-		} else {
-			// catches null regex matches
-			eventFacebookLinkElement.style.display = "none";
-		}
-	
-		// set text
-		document.getElementById("event-text-title").textContent = title;
-		document.getElementById("event-text-date").textContent = date;
-		document.getElementById("event-text-location").textContent = location;
-		let descStr = "";
-		for (let line in description) {
-			descStr += description[line].toString() + "\r\n";
-		}
-		document.getElementById("event-text-description").textContent = descStr; 
-		document.getElementById('calendar-event').style.display = "block"; //show
-	} else {
-		//null event
-		console.error("Event is null");
-	}
-	
+    // Facebook event button
+    let eventFacebookLinkElement = document.getElementById("facebook-link");
+    let link = parseFacebookLink(eventDataExtended.description);
+    if (link) {
+      eventFacebookLinkElement.onclick = () => {
+        window.open(link);
+      };
+      eventFacebookLinkElement.style.display = "inline";
+    } else {
+      // catches null regex matches
+      eventFacebookLinkElement.style.display = "none";
+    }
+
+    // set text
+    document.getElementById("event-text-title").textContent = title;
+    document.getElementById("event-text-date").textContent = date;
+    document.getElementById("event-text-location").textContent = location;
+    let descStr = "";
+    for (let line in description) {
+      descStr += description[line].toString() + "\r\n";
+    }
+    document.getElementById("event-text-description").textContent = descStr;
+    document.getElementById("calendar-event").style.display = "block"; //show
+  } else {
+    //null event
+    console.error("Event is null");
+  }
 }
 
 function hideEvent() {
-	// hide event information by hiding the element
-	document.getElementById('calendar-event').style.display = "none";
+  // hide event information by hiding the element
+  document.getElementById("calendar-event").style.display = "none";
 }
 
 function parseDescription(description) {
-	let retDesc = "";
-	let regex = new RegExp(/&lt;desc&gt;(.*?)&lt;\/desc\&gt;/, "g");
-	// parse and escape for <desc></desc> tags. toString prevent XSS
-	// make descripton string, checks for null if no description specified
-	description = description == null ? null : description.toString();
-	let match = regex.exec(description);
-	if (match != null) {
-		retDesc = match[1];
-	} else {
-		// null, so just use the description
-		retDesc = description;
-	}
-	// parse and split on <br>
-	if (retDesc) {
-		// checks for null
-		let regexBr = new RegExp(/\<br\>/, "g");
-		return retDesc.split(regexBr);
-		//returns list of lines
-	} else {
-		return retDesc;
-	}
-	
+  let retDesc = "";
+  let regex = new RegExp(/&lt;desc&gt;(.*?)&lt;\/desc\&gt;/, "g");
+  // parse and escape for <desc></desc> tags. toString prevent XSS
+  // make descripton string, checks for null if no description specified
+  description = description == null ? null : description.toString();
+  let match = regex.exec(description);
+  if (match != null) {
+    retDesc = match[1];
+  } else {
+    // null, so just use the description
+    retDesc = description;
+  }
+  // parse and split on <br>
+  if (retDesc) {
+    // checks for null
+    let regexBr = new RegExp(/\<br\>/, "g");
+    return retDesc.split(regexBr);
+    //returns list of lines
+  } else {
+    return retDesc;
+  }
 }
 
 function parseFacebookLink(description) {
-	let retLink = "";
-	let regex = new RegExp(/&lt;fb&gt;(.*?)&lt;\/fb\&gt;/);
-	// parse and escape for <fb></fb> tags. 
-	// make descripton string, checks for null if no description specified
-	description = description == null ? null : description.toString();
-	let match = regex.exec(description);
-	if (match != null) {
-		retLink = match[1];
-	}
-	// parse any <a> tags
-	let regexA = new RegExp(/\<a.*\>(.*?)\<\/a\>/);
-	// check for null
-	retLink = description == null ? null : retLink.toString();
-	match = regexA.exec(retLink);
-	if (match != null) {
-		retLink = match[1];
-	} 
-	return retLink;
+  let retLink = "";
+  let regex = new RegExp(/&lt;fb&gt;(.*?)&lt;\/fb\&gt;/);
+  // parse and escape for <fb></fb> tags.
+  // make descripton string, checks for null if no description specified
+  description = description == null ? null : description.toString();
+  let match = regex.exec(description);
+  if (match != null) {
+    retLink = match[1];
+  }
+  // parse any <a> tags
+  let regexA = new RegExp(/\<a.*\>(.*?)\<\/a\>/);
+  // check for null
+  retLink = description == null ? null : retLink.toString();
+  match = regexA.exec(retLink);
+  if (match != null) {
+    retLink = match[1];
+  }
+  return retLink;
 }

--- a/js/fadein.js
+++ b/js/fadein.js
@@ -1,35 +1,35 @@
-const CONTAINER = 'fadein-container';
-const FADEIN = 'fadein';
+const CONTAINER = "fadein-container";
+const FADEIN = "fadein";
 
-const DELAY_PREFIX = 'fadein-delay-';
+const DELAY_PREFIX = "fadein-delay-";
 
-window.addEventListener('load', () => {
-    let collections = document.getElementsByClassName(CONTAINER);
-    for (let collection of collections) {
-        // find delay in classes
-        let delay = 50;
-        for (let className of collection.classList) {
-            if (className.startsWith(DELAY_PREFIX)) {
-                delay = className.substring(DELAY_PREFIX.length);
-                break;
-            }
-        }
-
-        // gradually fade in
-        let fadeins = collection.getElementsByClassName(FADEIN);
-        let i = 0;
-        let appear = setInterval(() => {
-            if (i >= fadeins.length) {
-                clearInterval(appear);
-                return;
-            }
-
-            // we add 'visible' and remove 'hidden'
-            // but probably, the css styles will only use one
-            fadeins[i].classList.add('visible');
-            fadeins[i].classList.remove('hidden');
-
-            i++;
-        }, delay);
+window.addEventListener("load", () => {
+  let collections = document.getElementsByClassName(CONTAINER);
+  for (let collection of collections) {
+    // find delay in classes
+    let delay = 50;
+    for (let className of collection.classList) {
+      if (className.startsWith(DELAY_PREFIX)) {
+        delay = className.substring(DELAY_PREFIX.length);
+        break;
+      }
     }
+
+    // gradually fade in
+    let fadeins = collection.getElementsByClassName(FADEIN);
+    let i = 0;
+    let appear = setInterval(() => {
+      if (i >= fadeins.length) {
+        clearInterval(appear);
+        return;
+      }
+
+      // we add 'visible' and remove 'hidden'
+      // but probably, the css styles will only use one
+      fadeins[i].classList.add("visible");
+      fadeins[i].classList.remove("hidden");
+
+      i++;
+    }, delay);
+  }
 });

--- a/js/hamburger.js
+++ b/js/hamburger.js
@@ -1,20 +1,20 @@
-document.addEventListener('DOMContentLoaded', () => {
-    let hamburger = document.getElementById('hamburger');
-    let menu = document.getElementById('hamburger-menu');
+document.addEventListener("DOMContentLoaded", () => {
+  let hamburger = document.getElementById("hamburger");
+  let menu = document.getElementById("hamburger-menu");
 
-    hamburger.addEventListener('click', () => {
-        menu.classList.toggle('visible');
-    });
+  hamburger.addEventListener("click", () => {
+    menu.classList.toggle("visible");
+  });
 
-    menu.addEventListener('click', (event) => {
-        if (event.target == menu) {
-            menu.classList.toggle('visible');
-        }
-    });
+  menu.addEventListener("click", (event) => {
+    if (event.target == menu) {
+      menu.classList.toggle("visible");
+    }
+  });
 });
 
 function toggleShow(id) {
-  let x = document.getElementById("hbdd_"+id)
+  let x = document.getElementById("hbdd_" + id);
   if (x.style.display === "none") {
     x.style.display = "block";
   } else {


### PR DESCRIPTION
This PR adds a `Makefile` helper tool with a collection of useful utilities:

- `make build` to build the site into the `_site` directory
  - `make clean` to tidy up the artifacts from `make build`
- `make serve` to serve the site in a docker container (without messing up the `_site` directory, and making it owned by root :angry:, which is how I had it setup before)
- `make fmt` to use [prettier](https://prettier.io/) to autoformat SCSS and JS code, to prevent mixed tabs/spaces and to enforce a consistent style

The second commit is the result of running `make fmt` over the codebase :tada:

I can easily remove the auto-formatter if it's too controversial, but I very much like it :eyes: Ideally, it could also be integrated into a github action to cause a failure if `make fmt` hasn't been run.