### PR TITLE
Calendar html

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# start using prettier
+1123fb618adc2121453edfd2342f72d3b600c213

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,5 +3,6 @@
 !*.scss
 !*.js
 
-_site
+/vendor
+/_site
 /js/redirect.js


### PR DESCRIPTION
Fixes https://github.com/CSSUoB/cssuob.github.io/issues/117

This (currently work-in-progress) PR introduces support for loading HTML in the calendar description field.

To do this, we use Oliver's HTML sanitization method shared in the CSS discord - which needs a small amount of tidying up and manual verification (as well as handling of edge cases like `<3`, representing the heart emoji, which should not be parsed as an HTML tag).

(Additionally, this PR adds some prettier tidy-ups, which I'll probably cherry-pick over to a separate PR when I tidy this up if it's too much scope for here)