### PR TITLE
Fix GitHub prettier check

### DIFF
--- a/.github/workflows/check_prettier.yml
+++ b/.github/workflows/check_prettier.yml
@@ -1,6 +1,8 @@
 name: Check Prettier has been run
 
 on:
+  push:
+    branches: [master]
   pull_request:
     branches: [master]
 
@@ -10,8 +12,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Check formatting
         uses: creyD/prettier_action@v4.2


### PR DESCRIPTION
Fixes #337.

The failure emails are annoying :smile:

https://github.com/CSSUoB/cssuob.github.io/blob/45e0e9ecdb4a929bc5da8f1150bf1e646782084d/.github/workflows/check_prettier.yml#L13-L14

^ the guilty party, removing it gets the right ref each time.