### PR TITLE
Correct copyright footer in-line with new license change

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,3 @@
 <footer>
-    <p>© Computer Science Society {{ 'now' | date: "%Y" }}</p>
+    <p>© CSS website contributors {{ 'now' | date: "%Y" }}</p>
 </footer>


### PR DESCRIPTION
Oops :eyes:

This was actually never true! Copyright remains with the original authors, see #327 for more information.

The text "CSS website contributors" is pulled directly from the `README.md` where we lay out those details of the license information.