### PR TITLE
Remove interim committee from committee page

### DIFF
--- a/_data/committee/2022-23.yaml
+++ b/_data/committee/2022-23.yaml
@@ -144,6 +144,7 @@ people:
     discordtag: torisucks2020#7193
     role: Interim First Year Rep
     start-date: 1/7/2022
+    end-date: 27/10/2022
     picture: /assets/committee/2022-23/mini/tori.jpg
     bio: >
       Hi, I'm Tori and I'm a second year Computer Science student. I'm the Interim First Year Rep and I'll be helping organise 
@@ -154,6 +155,7 @@ people:
     discordtag: Thexxn#4799
     role: Interim PGT Rep
     start-date: 1/7/2022
+    end-date: 27/10/2022
     picture: /assets/committee/2022-23/mini/theo.png
     bio: >
       As Interim PGT Rep, I make sure that all Postgrad students on a taught course feel welcomed by CSS. I enjoy running, 


### PR DESCRIPTION
I put the date of the EGM as their end dates, I don't know "technically" when their terms are over according to the guild