### PR TITLE
Add quantum workshop to /clubs

### DIFF
--- a/_collections/_clubs/2022-11-23-quantum-workshop.md
+++ b/_collections/_clubs/2022-11-23-quantum-workshop.md
@@ -1,0 +1,14 @@
+---
+title: "Quantum Workshop"
+header-image: /assets/images/quantum-workshop.jpg
+---
+
+[Dr. Miriam Backens](https://www.cs.bham.ac.uk/~backensm/), lecturer and researcher at UoB, gave an introductory talk 
+to quantum computing. We covered the basics of quantum computing, some of its applications, and the theory behind 
+programming a quantum computer. 🤯
+
+Then, IBM gave us a tour of their quantum computing SDK, [Qiskit](https://qiskit.org/), and we got to play around 
+with builing our own quantum circuits and running them! ⚛️  
+
+The slides from Miriam's talk are available on
+[their personal webpage](https://www.cs.bham.ac.uk/~backensm/intro_to_QC_2022.pdf).


### PR DESCRIPTION
THis page really should be /workshops at this point since we barely do anything with GDSC 