### PR TITLE
Update email to guild email on about page

### DIFF
--- a/about.md
+++ b/about.md
@@ -146,6 +146,6 @@ Below are links to both our current Constitution and all previous agendas:
 
 ## Contact Us 📧
 
-[cssoc@cs.bham.ac.uk](mailto:cssoc@cs.bham.ac.uk)
+[css@guild.bham.ac.uk](mailto:css@guild.bham.ac.uk)
 
 <script src="https://kit.fontawesome.com/3e937b69c2.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
Updates the email on our about page from the old CS one to the guild one