### PR TITLE
Fix Prettier run and overly permissive regex check

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -314,7 +314,7 @@ function sanitizeTags(text, validTags, validProperties) {
   let result = "";
   for (;;) {
     const match = text.match(
-      /<(\/?)([a-zA-Z]+)([a-zA-Z0-9\s:\/&'"-_=]*?)(\/?)>/,
+      /<(\/?)([a-zA-Z]+)([a-zA-Z0-9\s:\/&'"\-_=]*?)(\/?)>/,
     );
     if (!match) {
       result += encodeHTML(text);

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -299,7 +299,7 @@ function parseHTML(html, otherValidTags = null, otherValidProperties = null) {
   html = sanitizeTags(
     html,
     validTags.concat(otherValidTags),
-    new Map([...validProperties, ...otherValidProperties])
+    new Map([...validProperties, ...otherValidProperties]),
   );
 
   let el = document.createElement("span");
@@ -314,7 +314,7 @@ function sanitizeTags(text, validTags, validProperties) {
   let result = "";
   for (;;) {
     const match = text.match(
-      /<(\/?)([a-zA-Z]+)([a-zA-Z0-9\s:\/&'"-_=]*?)(\/?)>/
+      /<(\/?)([a-zA-Z]+)([a-zA-Z0-9\s:\/&'"-_=]*?)(\/?)>/,
     );
     if (!match) {
       result += encodeHTML(text);
@@ -360,7 +360,7 @@ function encodeHTML(text) {
       // parse selected entities (because *someone* is pasting weird characters to the calendar)
       .replace(
         /\&(#?[a-z0-9]+);/g,
-        (match, group) => entityList.get(group) || match
+        (match, group) => entityList.get(group) || match,
       )
       // encode all dangerous characters to html entities
       .replace(/[\u00A0-\u9999<>\&]/g, (i) => "&#" + i.charCodeAt(0) + ";")

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -313,9 +313,7 @@ function parseHTML(html, otherValidTags = null, otherValidProperties = null) {
 function sanitizeTags(text, validTags, validProperties) {
   let result = "";
   for (;;) {
-    const match = text.match(
-      /<(\/?)([a-zA-Z]+)([a-zA-Z0-9\s:\/&'"-_=]*?)(\/?)>/,
-    );
+    const match = text.match(/<(\/?)([a-zA-Z]+)([a-zA-Z0-9\s:\/&'"-_=]*?)(\/?)>/);
     if (!match) {
       result += encodeHTML(text);
       break;

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -313,7 +313,9 @@ function parseHTML(html, otherValidTags = null, otherValidProperties = null) {
 function sanitizeTags(text, validTags, validProperties) {
   let result = "";
   for (;;) {
-    const match = text.match(/<(\/?)([a-zA-Z]+)([a-zA-Z0-9\s:\/&'"-_=]*?)(\/?)>/);
+    const match = text.match(
+      /<(\/?)([a-zA-Z]+)([a-zA-Z0-9\s:\/&'"-_=]*?)(\/?)>/,
+    );
     if (!match) {
       result += encodeHTML(text);
       break;


### PR DESCRIPTION
real shot in the dark but I ran the file through Prettier itself and it seemed suddenly upset about commas missing