### PR TITLE
Calendar Content Fixes

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -367,4 +367,7 @@ function encodeHTML(text) {
   );
 }
 
-const entityList = new Map([["nbsp", "\u00a0"], ["amp", "&"]]);
+const entityList = new Map([
+  ["nbsp", "\u00a0"],
+  ["amp", "&"],
+]);


### PR DESCRIPTION
- Removes the overly passive regex check and replaces it with symbols often found in a URL
- Add i and u as valid tags (for formatting)
- Parse the ampersand escape code - it is already a part of the description provided by Google Calendar