### PR TITLE
fix text overflowing the side of newsletter posts

### DIFF
--- a/css/posts.scss
+++ b/css/posts.scss
@@ -33,7 +33,7 @@ $preview-height: 150px;
   .post-details {
     flex: 1 1 auto;
     padding-left: 1em;
-    max-width: calc(100vw - 150px - 5% - 1em);
+    width: calc(100vw - 150px - 5% - 1em);
     background: white;
 
     .post-title {

--- a/css/posts.scss
+++ b/css/posts.scss
@@ -191,10 +191,12 @@ $preview-height: 150px;
   .post-preview {
     .post-details {
       .post-title {
+        font-size: min(6vw, 27px);
         margin-top: 0.2em;
         margin-bottom: 0.2em;
       }
       .post-date {
+        font-size: min(5vw, 27px);
         margin-top: 0.2em;
         margin-bottom: 0.2em;
       }

--- a/css/posts.scss
+++ b/css/posts.scss
@@ -190,7 +190,6 @@ $preview-height: 150px;
 @media only screen and (max-width: 600px) {
   .post-preview {
     .post-details {
-      
       .post-title {
         margin-top: 0.2em;
         margin-bottom: 0.2em;

--- a/css/posts.scss
+++ b/css/posts.scss
@@ -33,6 +33,7 @@ $preview-height: 150px;
   .post-details {
     flex: 1 1 auto;
     padding-left: 1em;
+    max-width: calc(100vw - 150px - 10%);
     background: white;
 
     .post-title {
@@ -189,6 +190,7 @@ $preview-height: 150px;
 @media only screen and (max-width: 600px) {
   .post-preview {
     .post-details {
+      
       .post-title {
         margin-top: 0.2em;
         margin-bottom: 0.2em;

--- a/css/posts.scss
+++ b/css/posts.scss
@@ -33,7 +33,7 @@ $preview-height: 150px;
   .post-details {
     flex: 1 1 auto;
     padding-left: 1em;
-    max-width: calc(100vw - 150px - 10%);
+    max-width: calc(100vw - 150px - 5% - 1em);
     background: white;
 
     .post-title {


### PR DESCRIPTION
Currently, text overflows the side of newsletter posts on smaller screen sizes. 
Fixed by setting the max-width of post-details to its calculated width.
