### PR TITLE
Add 'p' to allowed tags in calendar event descriptions (resolves #508)

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -294,7 +294,7 @@ function parseHTML(html, otherValidTags = null, otherValidProperties = null) {
     return null;
   }
 
-  const validTags = ["a", "b", "br", "code", "em", "i", "span", "strong", "u"];
+  const validTags = ["a", "b", "br", "code", "em", "i", "p", "span", "strong", "u"];
   const validProperties = new Map([["a", ["href"]]]);
   html = sanitizeTags(
     html,


### PR DESCRIPTION
html `<p>` tags are being incorrectly displayed as raw characters. Adds `p` to the filter to ensure they are rendered properly.