### PR TITLE
Add formatting to FullCalendar to properly render times (fixes CSSUoB#490)

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -54,6 +54,16 @@ document.addEventListener("DOMContentLoaded", () => {
     eventClick: function (event) {
       loadEvent(event);
     },
+    views: {
+      dayGrid: {
+        eventTimeFormat: {
+          hour: "numeric",
+          minute: "2-digit",
+          omitZeroMinute: true,
+          meridiem: "short",
+        },
+      },
+    },
   });
   calendar.render();
 


### PR DESCRIPTION
Configures the `dayGrid` view to format times with the full `am`/`pm`