### PR TITLE
Fix rendering for headers and lists in the calendar (fixes #655)

### DIFF
--- a/css/calendar.scss
+++ b/css/calendar.scss
@@ -46,7 +46,8 @@ $TeX-Purple: #9d68dc;
   margin-bottom: 10px;
   display: none;
 
-  h2,
+  h1, h2, h3, h4, h5, h6,
+  li,
   p {
     color: black;
     text-align: left;

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -304,7 +304,11 @@ function parseHTML(html, otherValidTags = null, otherValidProperties = null) {
     return null;
   }
 
-  const validTags = ["a", "b", "br", "code", "em", "i", "p", "span", "strong", "u"];
+  const validTags = [
+    "a", "b", "br", "code", "em", "i", "p", "span", "strong", "sup", "u",
+    "h1", "h2", "h3", "h4", "h5", "h6",
+    "ul", "ol", "li",
+  ];
   const validProperties = new Map([["a", ["href"]]]);
   html = sanitizeTags(
     html,
@@ -324,7 +328,7 @@ function sanitizeTags(text, validTags, validProperties) {
   let result = "";
   for (;;) {
     const match = text.match(
-      /<(\/?)([a-zA-Z]+)([a-zA-Z0-9\s:\/&'"\-_=.~?#*@'+,;%]*?)(\/?)>/,
+      /<(\/?)(h[1-6]|[a-zA-Z]+)([a-zA-Z0-9\s:\/&'"\-_=.~?#*@'+,;%]*?)(\/?)>/,
     );
     if (!match) {
       result += encodeHTML(text);


### PR DESCRIPTION
Adds header and lists to the allowed tags
Adds a special case to match against header tags
  (numbers were not detected as part of the tag)
Adds css rules to ensure headers and lists are visible
  (they were inheriting `color: white` from main.scss)