### PR TITLE
Add references to membership perks

### DIFF
--- a/membership.md
+++ b/membership.md
@@ -11,7 +11,7 @@ To take part in our bigger, ticketed events, you'll want to purchase a
 membership 🎉 It's £5 for the whole year and all of your membership money goes
 to running great events for other members, a lot of it going on pizza!
 
-In addition, you'll get an awesome free T-shirt 👕 and get to choose a snazzy colour role 💚🩷🧡💜💛❤️ on the [Discord](/discord)!
+In addition, you'll get an awesome free T-shirt 👕 and get to choose a snazzy colour role 💚🧡💜💛❤️ on the [Discord](/discord)!
 
 If you have any problems getting a membership, ask in #help on our Discord
 server, the Guild website can occasionally be a little temperamental!


### PR DESCRIPTION
I added reference to the free t-shirt perk and the Discord coloured roles on the membership page.
This fixes issue #839 and enhances the clarity of the signup benefits for new potential members.