### PR TITLE
Add attendance for 2025, 2026 Ball

### DIFF
--- a/_data/ball/2025.yaml
+++ b/_data/ball/2025.yaml
@@ -2,6 +2,7 @@ name: CSS BALL
 year: 2025
 location: Macdonald Burlington Hotel
 date: 4th April
+attendees: 170
 
 tickets:
   - type: 3 Course

--- a/_data/ball/2026.yaml
+++ b/_data/ball/2026.yaml
@@ -2,6 +2,7 @@ name: CSS BALL
 year: 2026
 location: Macdonald Burlington Hotel
 date: 27th March
+attendees: 137
 
 tickets:
   - type: 3 Course


### PR DESCRIPTION
CLOSES: #907 by adding attendance numbers for both the 2025 and 2026 Ball.